### PR TITLE
Add version to MANIFEST

### DIFF
--- a/custom_components/emporia_vue/manifest.json
+++ b/custom_components/emporia_vue/manifest.json
@@ -12,5 +12,6 @@
   "dependencies": [],
   "codeowners": [
     "@magico13"
-  ]
+  ],
+  "version": "0.3.1"
 }


### PR DESCRIPTION
Future versions of HomeAssistant will require version in the MANIFEST file. This is an error message from the log.

```
2021-03-21 20:05:26 WARNING (MainThread) [homeassistant.loader] No 'version' key in the manifest file for custom integration 'emporia_vue'. This will not be allowed in a future version of Home Assistant. Please report this to the maintainer of 'emporia_vue'
```