### PR TITLE
Fix missing variable declaration

### DIFF
--- a/custom_components/emporia_vue/__init__.py
+++ b/custom_components/emporia_vue/__init__.py
@@ -138,6 +138,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             )
             await coordinator_1min.async_config_entry_first_refresh()
             _LOGGER.info(f"1min Update data: {coordinator_1min.data}")
+        coordinator_1hr = None
         if scales_1hr:
             coordinator_1hr = DataUpdateCoordinator(
                 hass,


### PR DESCRIPTION
I saw an error in the logs like `coordinator_1hr referenced before assignment` on line 163, so I fixed the error. 

I am now seeing an authentication error, so it looks like the cloud database migration is still in progress. 