### PR TITLE
add manufacturer to device_info

### DIFF
--- a/custom_components/emporia_vue/sensor.py
+++ b/custom_components/emporia_vue/sensor.py
@@ -142,6 +142,7 @@ class CurrentVuePowerSensor(CoordinatorEntity, SensorEntity):
                 )
             },
             "name": dName,
+            "manufacturer": "Emporia",
             "model": self._device.model,
             "sw_version": self._device.firmware,
             # "via_device": self._device.device_gid # might be able to map the extender, nested outlets


### PR DESCRIPTION
Thanks for building the code for this.  Here's a simple PR that adds the manufactuer to the device info in HA.

Fixes #86 

