### PR TITLE
fix:  Required integration type

### DIFF
--- a/custom_components/emporia_vue/manifest.json
+++ b/custom_components/emporia_vue/manifest.json
@@ -10,5 +10,6 @@
   "dependencies": [],
   "codeowners": ["@magico13"],
   "iot_class": "cloud_polling",
+  "integration_type": "hub",
   "version": "0.8.0"
 }


### PR DESCRIPTION
Required in future version of home assistant as per: https://developers.home-assistant.io/docs/creating_integration_manifest/