### PR TITLE
chore:  Github checks for HACS

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,22 @@
+name: Validate
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate-hassfest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Hassfest validation
+        uses: home-assistant/actions/hassfest@master
+
+  validate-hacs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration

--- a/custom_components/emporia_vue/manifest.json
+++ b/custom_components/emporia_vue/manifest.json
@@ -3,6 +3,7 @@
   "name": "Emporia Vue",
   "config_flow": true,
   "documentation": "https://github.com/magico13/ha-emporia-vue",
+  "issue_tracker": "https://github.com/magico13/ha-emporia-vue/issues",
   "requirements": ["pyemvue==0.16.1"],
   "ssdp": [],
   "zeroconf": [],

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
     "name": "Emporia Vue",
     "render_readme": true,
-    "homeassistant": "2021.9.0"
+    "homeassistant": "2021.9.0",
     "content_in_root": false
 }


### PR DESCRIPTION
HACS checks required for HACS integration.  These would be required if you want to make this a HACS included repo in the future.   If not all good feel free to reject.  It also has a few fixes I added to pass these checks.  I believe you will still need topic tags on the repo.

Contribute to: https://github.com/magico13/ha-emporia-vue/issues/22