### PR TITLE
fix: Invalid services.yaml

### DIFF
--- a/custom_components/emporia_vue/services.yaml
+++ b/custom_components/emporia_vue/services.yaml
@@ -6,7 +6,7 @@ set_charger_current:
   # If the service accepts entity IDs, target allows the user to specify entities by entity, device, or area. If `target` is specified, `entity_id` should not be defined in the `fields` map. By default it shows only targets matching entities from the same domain as the service, but if further customization is required, target supports the entity, device, and area selectors (https://www.home-assistant.io/docs/blueprint/selectors/). Entity selector parameters will automatically be applied to device and area, and device selector parameters will automatically be applied to area.
   target:
     entity:
-      manufacturer: Emporia
+      integration: emporia_vue
       device_class: outlet
       multiple: false
     device:

--- a/custom_components/emporia_vue/services.yaml
+++ b/custom_components/emporia_vue/services.yaml
@@ -13,6 +13,9 @@ set_charger_current:
       manufacturer: Emporia
       model: VVDN01
       multiple: false
+      entity:
+        integration: emporia_vue
+        device_class: outlet
   # Different fields that your service accepts
   fields:
     # Key of the field


### PR DESCRIPTION
Correction to continue removing errors for HACS store.   Entity type can't use manufacturer as per: https://www.home-assistant.io/docs/blueprint/selectors/#entity-selector

Please test as I don't have a charger. 