### PR TITLE
v0.10.0 Updates

### DIFF
--- a/custom_components/emporia_vue/charger_entity.py
+++ b/custom_components/emporia_vue/charger_entity.py
@@ -1,10 +1,11 @@
 """Emporia Charger Entity."""
 from typing import Any, Optional
 
-from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pyemvue import pyemvue
 from pyemvue.device import ChargerDevice, VueDevice
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 

--- a/custom_components/emporia_vue/charger_entity.py
+++ b/custom_components/emporia_vue/charger_entity.py
@@ -69,7 +69,7 @@ class EmporiaChargerEntity(CoordinatorEntity):
     def device_info(self) -> DeviceInfo:
         """Return the device information."""
         return DeviceInfo(
-            identifiers={(DOMAIN, self._device.device_gid)},
+            identifiers={(DOMAIN, f"{self._device.device_gid}-1,2,3")},
             name=self._device.device_name,
             model=self._device.model,
             sw_version=self._device.firmware,

--- a/custom_components/emporia_vue/charger_entity.py
+++ b/custom_components/emporia_vue/charger_entity.py
@@ -1,10 +1,10 @@
 """Emporia Charger Entity."""
 from typing import Any, Optional
 
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pyemvue import pyemvue
 from pyemvue.device import ChargerDevice, VueDevice
-
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 
@@ -30,10 +30,16 @@ class EmporiaChargerEntity(CoordinatorEntity):
 
         self._attr_unit_of_measurement = units
         self._attr_device_class = device_class
-        self._attr_name = device.device_name
+        self._attr_has_entity_name = True
+        self._attr_name = None
 
     @property
-    def entity_registry_enabled_default(self):
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._device
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
         """Return whether the entity should be enabled when first added to the entity registry."""
         return self._enabled_default
 
@@ -60,17 +66,14 @@ class EmporiaChargerEntity(CoordinatorEntity):
         return f"charger.emporia_vue.{self._device.device_gid}"
 
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return the device information."""
-        return {
-            "identifiers": {(DOMAIN, f"{self._device.device_gid}-1,2,3")},
-            "name": self._device.device_name + "-1,2,3",
-            "model": self._device.model,
-            "sw_version": self._device.firmware,
-            "manufacturer": "Emporia",
-        }
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device.device_gid)},
+            name=self._device.device_name,
+            model=self._device.model,
+            sw_version=self._device.firmware,
+            manufacturer="Emporia",
+        )
 
-    @property
-    def available(self):
-        """Return True if entity is available."""
-        return self._device
+

--- a/custom_components/emporia_vue/config_flow.py
+++ b/custom_components/emporia_vue/config_flow.py
@@ -1,12 +1,13 @@
 """Config flow for Emporia Vue integration."""
+
 import asyncio
 import logging
 
+from pyemvue import PyEmVue
 import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
-from homeassistant.data_entry_flow import FlowResult
 
 from .const import DOMAIN, ENABLE_1D, ENABLE_1M, ENABLE_1MON
 
@@ -18,7 +19,7 @@ DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_PASSWORD): str,
         vol.Optional(ENABLE_1M, default=True): bool,
         vol.Optional(ENABLE_1D, default=True): bool,
-        vol.Optional(ENABLE_1MON, default=True): bool
+        vol.Optional(ENABLE_1MON, default=True): bool,
     }
 )
 
@@ -56,7 +57,7 @@ async def validate_input(hass: core.HomeAssistant, data):
         "gid": f"{hub.vue.customer.customer_gid}",
         ENABLE_1M: data[ENABLE_1M],
         ENABLE_1D: data[ENABLE_1D],
-        ENABLE_1MON: data[ENABLE_1MON]
+        ENABLE_1MON: data[ENABLE_1MON],
     }
 
 
@@ -66,13 +67,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
-    async def async_step_user(self, user_input=None) -> FlowResult:
+    async def async_step_user(self, user_input=None) -> config_entries.ConfigFlowResult:
         """Handle the initial step."""
         errors = {}
         if user_input is not None:
             try:
                 info = await validate_input(self.hass, user_input)
-                #prevent setting up the same account twice
+                # prevent setting up the same account twice
                 await self.async_set_unique_id(info["gid"])
                 self._abort_if_unique_id_configured()
 

--- a/custom_components/emporia_vue/config_flow.py
+++ b/custom_components/emporia_vue/config_flow.py
@@ -7,7 +7,6 @@ import voluptuous as vol
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.data_entry_flow import FlowResult
-from pyemvue import PyEmVue
 
 from .const import DOMAIN, ENABLE_1D, ENABLE_1M, ENABLE_1MON
 
@@ -34,8 +33,7 @@ class VueHub:
     async def authenticate(self, username, password) -> bool:
         """Test if we can authenticate with the host."""
         loop = asyncio.get_event_loop()
-        result = await loop.run_in_executor(None, self.vue.login, username, password)
-        return result
+        return await loop.run_in_executor(None, self.vue.login, username, password)
 
 
 async def validate_input(hass: core.HomeAssistant, data):

--- a/custom_components/emporia_vue/config_flow.py
+++ b/custom_components/emporia_vue/config_flow.py
@@ -2,11 +2,12 @@
 import asyncio
 import logging
 
-from pyemvue import PyEmVue
 import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.data_entry_flow import FlowResult
+from pyemvue import PyEmVue
 
 from .const import DOMAIN, ENABLE_1D, ENABLE_1M, ENABLE_1MON
 
@@ -26,10 +27,9 @@ DATA_SCHEMA = vol.Schema(
 class VueHub:
     """Hub for the Emporia Vue Integration."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize."""
         self.vue = PyEmVue()
-        pass
 
     async def authenticate(self, username, password) -> bool:
         """Test if we can authenticate with the host."""
@@ -68,7 +68,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(self, user_input=None) -> FlowResult:
         """Handle the initial step."""
         errors = {}
         if user_input is not None:

--- a/custom_components/emporia_vue/manifest.json
+++ b/custom_components/emporia_vue/manifest.json
@@ -9,8 +9,8 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/magico13/ha-emporia-vue/issues",
-  "requirements": ["pyemvue==0.18.3"],
+  "requirements": ["pyemvue==0.18.4"],
   "ssdp": [],
-  "version": "0.9.2",
+  "version": "0.9.3",
   "zeroconf": []
 }

--- a/custom_components/emporia_vue/manifest.json
+++ b/custom_components/emporia_vue/manifest.json
@@ -9,8 +9,8 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/magico13/ha-emporia-vue/issues",
-  "requirements": ["pyemvue==0.18.4"],
+  "requirements": ["pyemvue==0.18.5"],
   "ssdp": [],
-  "version": "0.9.3",
+  "version": "0.9.4",
   "zeroconf": []
 }

--- a/custom_components/emporia_vue/manifest.json
+++ b/custom_components/emporia_vue/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/magico13/ha-emporia-vue/issues",
   "requirements": ["pyemvue==0.18.6"],
   "ssdp": [],
-  "version": "0.9.5",
+  "version": "0.10.0",
   "zeroconf": []
 }

--- a/custom_components/emporia_vue/manifest.json
+++ b/custom_components/emporia_vue/manifest.json
@@ -9,8 +9,8 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/magico13/ha-emporia-vue/issues",
-  "requirements": ["pyemvue==0.18.5"],
+  "requirements": ["pyemvue==0.18.6"],
   "ssdp": [],
-  "version": "0.9.4",
+  "version": "0.9.5",
   "zeroconf": []
 }

--- a/custom_components/emporia_vue/sensor.py
+++ b/custom_components/emporia_vue/sensor.py
@@ -1,18 +1,21 @@
 """Platform for sensor integration."""
+from datetime import datetime
 import logging
 from typing import Optional
-
-from pyemvue.device import VueDevice, VueDeviceChannel
-from pyemvue.enums import Scale
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorStateClass,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfEnergy, UnitOfPower
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from pyemvue.device import VueDevice, VueDeviceChannel
+from pyemvue.enums import Scale
 
 from .const import DOMAIN
 
@@ -20,7 +23,11 @@ _LOGGER = logging.getLogger(__name__)
 
 
 # def setup_platform(hass, config, add_entities, discovery_info=None):
-async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entities):
+async def async_setup_entry(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback
+    ) -> None:
     """Set up the sensor platform."""
     coordinator_1min = hass.data[DOMAIN][config_entry.entry_id]["coordinator_1min"]
     coordinator_1mon = hass.data[DOMAIN][config_entry.entry_id]["coordinator_1mon"]
@@ -60,13 +67,13 @@ class CurrentVuePowerSensor(CoordinatorEntity, SensorEntity):
         device_gid: int = coordinator.data[identifier]["device_gid"]
         channel_num: str = coordinator.data[identifier]["channel_num"]
         self._device: VueDevice = coordinator.data[identifier]["info"]
-        self._channel: Optional[VueDeviceChannel] = None
+        final_channel: Optional[VueDeviceChannel] = None
         if self._device is not None:
             for channel in self._device.channels:
                 if channel.channel_num == channel_num:
-                    self._channel = channel
+                    final_channel = channel
                     break
-        if self._channel is None:
+        if final_channel is None:
             _LOGGER.warning(
                 "No channel found for device_gid %s and channel_num %s",
                 device_gid,
@@ -75,30 +82,45 @@ class CurrentVuePowerSensor(CoordinatorEntity, SensorEntity):
             raise RuntimeError(
                 f"No channel found for device_gid {device_gid} and channel_num {channel_num}"
             )
-        device_name = self._device.device_name
-        if self._channel.name and self._channel.name not in [
-            "Main",
-            "Balance",
-            "TotalUsage",
-            "MainsToGrid",
-            "MainsFromGrid",
-        ]:
-            device_name = self._channel.name
-        self._name = f"{device_name} {channel_num} {self._scale}"
+        self._channel: VueDeviceChannel = final_channel
         self._iskwh = self.scale_is_energy()
 
-        self._attr_name = self._name
+        self._attr_has_entity_name = True
+        self._attr_suggested_display_precision = 3
         if self._iskwh:
             self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
             self._attr_device_class = SensorDeviceClass.ENERGY
             self._attr_state_class = SensorStateClass.TOTAL
+            self._attr_name = f"Energy {self._scale}"
         else:
             self._attr_native_unit_of_measurement = UnitOfPower.WATT
             self._attr_device_class = SensorDeviceClass.POWER
             self._attr_state_class = SensorStateClass.MEASUREMENT
+            self._attr_name = f"Power {self._scale}"
 
     @property
-    def native_value(self):
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        device_name = self._channel.name or self._device.device_name
+        return DeviceInfo(
+            identifiers={
+                (DOMAIN, f"{self._device.device_gid}-{self._channel.channel_num}")
+            },
+            name=device_name,
+            model=self._device.model,
+            sw_version=self._device.firmware,
+            manufacturer="Emporia",
+        )
+
+    @property
+    def last_reset(self) -> datetime | None:
+        """The time when the daily/monthly sensor was reset. Midnight local time."""
+        if self._id in self.coordinator.data:
+            return self.coordinator.data[self._id]["reset"]
+        return None
+
+    @property
+    def native_value(self) -> float | None:
         """Return the state of the sensor."""
         if self._id in self.coordinator.data:
             usage = self.coordinator.data[self._id]["usage"]
@@ -106,50 +128,20 @@ class CurrentVuePowerSensor(CoordinatorEntity, SensorEntity):
         return None
 
     @property
-    def last_reset(self):
-        """The time when the daily/monthly sensor was reset. Midnight local time."""
-        if self._id in self.coordinator.data:
-            return self.coordinator.data[self._id]["reset"]
-        return None
-
-    @property
-    def unique_id(self):
+    def unique_id(self) -> str:
         """Unique ID for the sensor."""
         if self._scale == Scale.MINUTE.value:
             return f"sensor.emporia_vue.instant.{self._channel.device_gid}-{self._channel.channel_num}"
         return f"sensor.emporia_vue.{self._scale}.{self._channel.device_gid}-{self._channel.channel_num}"
 
-    @property
-    def device_info(self):
-        """Return the device info."""
-        device_name = self._channel.name or self._device.device_name
-        return {
-            "identifiers": {
-                # Serial numbers are unique identifiers within a specific domain
-                (
-                    DOMAIN,
-                    f"{self._device.device_gid}-{self._channel.channel_num}",
-                )
-            },
-            "name": device_name,
-            "model": self._device.model,
-            "sw_version": self._device.firmware,
-            "manufacturer": "Emporia"
-            # "via_device": self._device.device_gid # might be able to map the extender, nested outlets
-        }
-
     def scale_usage(self, usage):
         """Scales the usage to the correct timescale and magnitude."""
         if self._scale == Scale.MINUTE.value:
-            usage = round(60 * 1000 * usage)  # convert from kwh to w rate
+            usage = 60 * 1000 * usage  # convert from kwh to w rate
         elif self._scale == Scale.SECOND.value:
-            usage = round(3600 * 1000 * usage)  # convert to rate
+            usage = 3600 * 1000 * usage  # convert to rate
         elif self._scale == Scale.MINUTES_15.value:
-            usage = round(
-                4 * 1000 * usage
-            )  # this might never be used but for safety, convert to rate
-        else:
-            usage = round(usage, 3)
+            usage = 4 * 1000 * usage # this might never be used but for safety, convert to rate
         return usage
 
     def scale_is_energy(self):

--- a/custom_components/emporia_vue/sensor.py
+++ b/custom_components/emporia_vue/sensor.py
@@ -87,17 +87,18 @@ class CurrentVuePowerSensor(CoordinatorEntity, SensorEntity):
         self._iskwh = self.scale_is_energy()
 
         self._attr_has_entity_name = True
-        self._attr_suggested_display_precision = 3
         if self._iskwh:
             self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
             self._attr_device_class = SensorDeviceClass.ENERGY
             self._attr_state_class = SensorStateClass.TOTAL
-            self._attr_name = f"Energy {self._scale}"
+            self._attr_suggested_display_precision = 3
+            self._attr_name = f"Energy {self.scale_readable()}"
         else:
             self._attr_native_unit_of_measurement = UnitOfPower.WATT
             self._attr_device_class = SensorDeviceClass.POWER
             self._attr_state_class = SensorStateClass.MEASUREMENT
-            self._attr_name = f"Power {self._scale}"
+            self._attr_suggested_display_precision = 1
+            self._attr_name = f"Power {self.scale_readable()}"
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -154,3 +155,13 @@ class CurrentVuePowerSensor(CoordinatorEntity, SensorEntity):
             Scale.SECOND.value,
             Scale.MINUTES_15.value,
         )
+    
+    def scale_readable(self):
+        """Return a human readable scale."""
+        if self._scale == Scale.MINUTE.value:
+            return "Minute Average"
+        if self._scale == Scale.DAY.value:
+            return "Today"
+        if self._scale == Scale.MONTH.value:
+            return "This Month"
+        return self._scale

--- a/custom_components/emporia_vue/switch.py
+++ b/custom_components/emporia_vue/switch.py
@@ -136,7 +136,7 @@ class EmporiaOutletSwitch(CoordinatorEntity, SwitchEntity):
     def device_info(self) -> DeviceInfo:
         """Return the device information."""
         return DeviceInfo(
-            identifiers={(DOMAIN, str(self._device_gid))},
+            identifiers={(DOMAIN, f"{self._device_gid}-1,2,3")},
             name=self._device.device_name,
             model=self._device.model,
             sw_version=self._device.firmware,

--- a/custom_components/emporia_vue/translations/en.json
+++ b/custom_components/emporia_vue/translations/en.json
@@ -12,10 +12,10 @@
             "user": {
                 "data": {
                     "email": "Email",
-                    "enable_1d": "One Day Sensor",
-                    "enable_1m": "One Minute Sensor",
-                    "enable_1mon": "One Month Sensor",
-                    "enable_1s": "One Second Sensor",
+                    "enable_1d": "Energy Today Sensor",
+                    "enable_1m": "Power Minute Average Sensor",
+                    "enable_1mon": "Energy This Month Sensor",
+                    "enable_1s": "Power Second Average Sensor",
                     "password": "Password"
                 }
             }

--- a/custom_components/emporia_vue/translations/en.json
+++ b/custom_components/emporia_vue/translations/en.json
@@ -4,7 +4,7 @@
             "already_configured": "Device is already configured"
         },
         "error": {
-            "cannot_connect": "Failed to connect, please try again",
+            "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",
             "unknown": "Unexpected error"
         },
@@ -12,11 +12,11 @@
             "user": {
                 "data": {
                     "email": "Email",
-                    "password": "Password",
-                    "enable_1s": "One Second Sensor",
-                    "enable_1m": "One Minute Sensor",
                     "enable_1d": "One Day Sensor",
-                    "enable_1mon": "One Month Sensor"
+                    "enable_1m": "One Minute Sensor",
+                    "enable_1mon": "One Month Sensor",
+                    "enable_1s": "One Second Sensor",
+                    "password": "Password"
                 }
             }
         }


### PR DESCRIPTION
- Bumped version to 0.10.0. 
- Updated sensor names to more closely follow Home Assistant's recommended naming conventions. Only changes them if they're still set to the default, you can still rename them.
- Addressed Home Assistant warnings about deprecated functionality and also numerous linter recommendations.\
- Bumped PyEmVue to 0.18.6, which includes improvements to the authentication flow and supports bidirectional circuits.