### PR TITLE
Initial Support for Re-Auth and Reconfiguration

### DIFF
--- a/custom_components/emporia_vue/__init__.py
+++ b/custom_components/emporia_vue/__init__.py
@@ -91,7 +91,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     vue = PyEmVue()
     loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
     try:
-        result: bool = await loop.run_in_executor(None, vue.login, email, password)
+        # support using the simulator by looking at the username
+        if email.startswith("vue_simulator@"):
+            host = email.split("@")[1]
+            result: bool = await loop.run_in_executor(None, vue.login_simulator, host)
+        else:
+            result: bool = await loop.run_in_executor(None, vue.login, email, password)
         if not result:
             _LOGGER.error("Failed to login to Emporia Vue")
             raise ConfigEntryAuthFailed("Failed to login to Emporia Vue")

--- a/custom_components/emporia_vue/__init__.py
+++ b/custom_components/emporia_vue/__init__.py
@@ -93,7 +93,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     DEVICE_INFORMATION = {}
 
     entry_data = entry.data
-    _LOGGER.warning("Setting up Emporia Vue with entry data: %s", entry_data)
+    _LOGGER.debug("Setting up Emporia Vue with entry data: %s", entry_data)
     email: str = entry_data[CONF_EMAIL]
     password: str = entry_data[CONF_PASSWORD]
     vue = PyEmVue()
@@ -199,7 +199,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 update_interval=timedelta(minutes=1),
             )
             await coordinator_1min.async_config_entry_first_refresh()
-            _LOGGER.info("1min Update data: %s", coordinator_1min.data)
+            _LOGGER.debug("1min Update data: %s", coordinator_1min.data)
         coordinator_1mon = None
         if ENABLE_1MON not in entry_data or entry_data[ENABLE_1MON]:
             coordinator_1mon = DataUpdateCoordinator(
@@ -212,7 +212,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 update_interval=timedelta(hours=1),
             )
             await coordinator_1mon.async_config_entry_first_refresh()
-            _LOGGER.info("1mon Update data: %s", coordinator_1mon.data)
+            _LOGGER.debug("1mon Update data: %s", coordinator_1mon.data)
 
         coordinator_day_sensor = None
         if ENABLE_1D not in entry_data or entry_data[ENABLE_1D]:

--- a/custom_components/emporia_vue/__init__.py
+++ b/custom_components/emporia_vue/__init__.py
@@ -38,6 +38,9 @@ from .const import (
     ENABLE_1D,
     ENABLE_1M,
     ENABLE_1MON,
+    MERGED_ABS,
+    MERGED_BEHAVIOR,
+    MERGED_INVERT,
     VUE_DATA,
 )
 
@@ -51,6 +54,7 @@ DEVICES_ONLINE: list[str] = []
 LAST_MINUTE_DATA: dict[str, Any] = {}
 LAST_DAY_DATA: dict[str, Any] = {}
 LAST_DAY_UPDATE: datetime | None = None
+CONF_MERGED_BEHAVIOR: str = MERGED_INVERT
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Emporia Vue component."""
@@ -58,6 +62,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     conf = config.get(DOMAIN)
     if not conf:
         return True
+
+    global CONF_MERGED_BEHAVIOR
+    if MERGED_BEHAVIOR in conf:
+        CONF_MERGED_BEHAVIOR = conf[MERGED_BEHAVIOR]
 
     hass.async_create_task(
         hass.config_entries.flow.async_init(
@@ -69,6 +77,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 ENABLE_1M: conf[ENABLE_1M],
                 ENABLE_1D: conf[ENABLE_1D],
                 ENABLE_1MON: conf[ENABLE_1MON],
+                MERGED_BEHAVIOR: conf[MERGED_BEHAVIOR],
                 CUSTOMER_GID: conf[CUSTOMER_GID],
                 CONFIG_TITLE: conf[CONFIG_TITLE],
             },
@@ -481,11 +490,9 @@ async def parse_flattened_usage_data(
                     fixed_usage,
                 )
 
-            bidirectional = (
-                "bidirectional" in info_channel.type.lower()
-                or "merged" in info_channel.type.lower()
-            )
-            fixed_usage = fix_usage_sign(channel_num, fixed_usage, bidirectional)
+            bidirectional = "bidirectional" in info_channel.type.lower()
+            merged = "merged" in info_channel.type.lower()
+            fixed_usage = fix_usage_sign(channel_num, fixed_usage, bidirectional, merged, CONF_MERGED_BEHAVIOR)
 
             data[identifier] = {
                 "device_gid": gid,
@@ -565,11 +572,20 @@ def make_channel_id(channel: VueDeviceChannel, scale: str) -> str:
     return f"{channel.device_gid}-{channel.channel_num}-{scale}"
 
 
-def fix_usage_sign(channel_num: str, usage: float, bidirectional: bool) -> float:
+def fix_usage_sign(channel_num: str, usage: float, bidirectional: bool, merged:bool, merged_behavior: str) -> float:
     """If the channel is not '1,2,3' or 'Balance' we need it to be positive.
+
+    Merged circuits are a special case, as they can be inverted, abs'd, or left alone to support different solar setups.
 
     (see https://github.com/magico13/ha-emporia-vue/issues/57)
     """
+    if merged:
+        # for merged channels, we need to either invert or abs the value as requested
+        if merged_behavior == MERGED_ABS:
+            return abs(usage)
+        if merged_behavior == MERGED_INVERT:
+            return -usage
+        return usage
 
     if usage and not bidirectional and channel_num not in ["1,2,3", "Balance"]:
         # With bidirectionality, we need to also check if bidirectional. If yes,

--- a/custom_components/emporia_vue/config_flow.py
+++ b/custom_components/emporia_vue/config_flow.py
@@ -124,10 +124,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the reconfiguration step."""
         current_config = self._get_reconfigure_entry()
         if user_input is not None:
-            _LOGGER.warning(
-                "User input on reconfigure was the following: %s", user_input
-            )
-            _LOGGER.warning("Current config is: %s", current_config.data)
+            _LOGGER.debug("User input on reconfigure was the following: %s", user_input)
+            _LOGGER.debug("Current config is: %s", current_config.data)
             info = current_config.data
             # if gid is not in current config, reauth and get gid again
             if (

--- a/custom_components/emporia_vue/const.py
+++ b/custom_components/emporia_vue/const.py
@@ -1,42 +1,16 @@
 """Constants for the Emporia Vue integration."""
 
-import voluptuous as vol
-
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
-import homeassistant.helpers.config_validation as cv
-
 DOMAIN = "emporia_vue"
 VUE_DATA = "vue_data"
 ENABLE_1S = "enable_1s"
 ENABLE_1M = "enable_1m"
 ENABLE_1D = "enable_1d"
 ENABLE_1MON = "enable_1mon"
+MERGED_BEHAVIOR = "merged_behavior"
 CUSTOMER_GID = "customer_gid"
 CONFIG_TITLE = "title"
 
-USER_CONFIG_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_EMAIL): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(ENABLE_1M, default=True): cv.boolean,  # type: ignore
-        vol.Optional(ENABLE_1D, default=True): cv.boolean,  # type: ignore
-        vol.Optional(ENABLE_1MON, default=True): cv.boolean,  # type: ignore
-    }
-)
+MERGED_INVERT = "Invert"
+MERGED_ABS = "Absolute Value"
+MERGED_NONE = "None"
 
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_EMAIL): cv.string,
-                vol.Required(CONF_PASSWORD): cv.string,
-                vol.Optional(ENABLE_1M, default=True): cv.boolean,  # type: ignore
-                vol.Optional(ENABLE_1D, default=True): cv.boolean,  # type: ignore
-                vol.Optional(ENABLE_1MON, default=True): cv.boolean,  # type: ignore
-                vol.Required(CUSTOMER_GID): cv.positive_int,
-                vol.Required(CONFIG_TITLE): cv.string,
-            }
-        ),
-    },
-    extra=vol.ALLOW_EXTRA,
-)

--- a/custom_components/emporia_vue/const.py
+++ b/custom_components/emporia_vue/const.py
@@ -6,11 +6,6 @@ ENABLE_1S = "enable_1s"
 ENABLE_1M = "enable_1m"
 ENABLE_1D = "enable_1d"
 ENABLE_1MON = "enable_1mon"
-MERGED_BEHAVIOR = "merged_behavior"
+SOLAR_INVERT = "solar_invert"
 CUSTOMER_GID = "customer_gid"
 CONFIG_TITLE = "title"
-
-MERGED_INVERT = "Invert"
-MERGED_ABS = "Absolute Value"
-MERGED_NONE = "None"
-

--- a/custom_components/emporia_vue/const.py
+++ b/custom_components/emporia_vue/const.py
@@ -1,8 +1,9 @@
 """Constants for the Emporia Vue integration."""
 
-import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
+
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+import homeassistant.helpers.config_validation as cv
 
 DOMAIN = "emporia_vue"
 VUE_DATA = "vue_data"
@@ -10,8 +11,10 @@ ENABLE_1S = "enable_1s"
 ENABLE_1M = "enable_1m"
 ENABLE_1D = "enable_1d"
 ENABLE_1MON = "enable_1mon"
+CUSTOMER_GID = "customer_gid"
+CONFIG_TITLE = "title"
 
-DOMAIN_SCHEMA = vol.Schema(
+USER_CONFIG_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_EMAIL): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
@@ -23,7 +26,17 @@ DOMAIN_SCHEMA = vol.Schema(
 
 CONFIG_SCHEMA = vol.Schema(
     {
-        DOMAIN: DOMAIN_SCHEMA,
+        DOMAIN: vol.Schema(
+            {
+                vol.Required(CONF_EMAIL): cv.string,
+                vol.Required(CONF_PASSWORD): cv.string,
+                vol.Optional(ENABLE_1M, default=True): cv.boolean,  # type: ignore
+                vol.Optional(ENABLE_1D, default=True): cv.boolean,  # type: ignore
+                vol.Optional(ENABLE_1MON, default=True): cv.boolean,  # type: ignore
+                vol.Required(CUSTOMER_GID): cv.positive_int,
+                vol.Required(CONFIG_TITLE): cv.string,
+            }
+        ),
     },
     extra=vol.ALLOW_EXTRA,
 )

--- a/custom_components/emporia_vue/manifest.json
+++ b/custom_components/emporia_vue/manifest.json
@@ -4,16 +4,10 @@
   "codeowners": ["@magico13"],
   "config_flow": true,
   "single_config_entry": true,
-  "dependencies": [],
   "documentation": "https://github.com/magico13/ha-emporia-vue",
-  "homekit": {},
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/magico13/ha-emporia-vue/issues",
-  "requirements": [
-    "pyemvue@git+https://github.com/magico13/pyemvue.git@a3f9da4baa471d4aa32ca795756cb65c554ef89d"
-  ],
-  "ssdp": [],
-  "version": "0.10.2",
-  "zeroconf": []
+  "requirements": ["pyemvue==0.18.7"],
+  "version": "0.10.3"
 }

--- a/custom_components/emporia_vue/manifest.json
+++ b/custom_components/emporia_vue/manifest.json
@@ -3,13 +3,16 @@
   "name": "Emporia Vue",
   "codeowners": ["@magico13"],
   "config_flow": true,
+  "single_config_entry": true,
   "dependencies": [],
   "documentation": "https://github.com/magico13/ha-emporia-vue",
   "homekit": {},
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/magico13/ha-emporia-vue/issues",
-  "requirements": ["pyemvue==0.18.6"],
+  "requirements": [
+    "pyemvue@git+https://github.com/magico13/pyemvue.git@a3f9da4baa471d4aa32ca795756cb65c554ef89d"
+  ],
   "ssdp": [],
   "version": "0.10.2",
   "zeroconf": []

--- a/custom_components/emporia_vue/sensor.py
+++ b/custom_components/emporia_vue/sensor.py
@@ -100,6 +100,7 @@ class CurrentVuePowerSensor(CoordinatorEntity, SensorEntity):  # type: ignore
             self._attr_suggested_display_precision = 1
             self._attr_name = f"Power {self.scale_readable()}"
 
+    @property
     def device_info(self) -> DeviceInfo:
         """Return the device info."""
         device_name = self._channel.name or self._device.device_name
@@ -113,12 +114,14 @@ class CurrentVuePowerSensor(CoordinatorEntity, SensorEntity):  # type: ignore
             manufacturer="Emporia",
         )
 
+    @property
     def last_reset(self) -> datetime | None:
         """Reset time of the daily/monthly sensor. Midnight local time."""
         if self._id in self.coordinator.data:
             return self.coordinator.data[self._id]["reset"]
         return None
 
+    @property
     def native_value(self) -> float | None:
         """Return the state of the sensor."""
         if self._id in self.coordinator.data:
@@ -126,6 +129,7 @@ class CurrentVuePowerSensor(CoordinatorEntity, SensorEntity):  # type: ignore
             return self.scale_usage(usage) if usage is not None else None
         return None
 
+    @property
     def unique_id(self) -> str:
         """Return the Unique ID for the sensor."""
         if self._scale == Scale.MINUTE.value:

--- a/custom_components/emporia_vue/sensor.py
+++ b/custom_components/emporia_vue/sensor.py
@@ -1,8 +1,10 @@
 """Platform for sensor integration."""
 
-import logging
 from datetime import datetime
-from functools import cached_property
+import logging
+
+from pyemvue.device import VueDevice, VueDeviceChannel
+from pyemvue.enums import Scale
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -15,8 +17,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from pyemvue.device import VueDevice, VueDeviceChannel
-from pyemvue.enums import Scale
 
 from .const import DOMAIN
 
@@ -100,7 +100,6 @@ class CurrentVuePowerSensor(CoordinatorEntity, SensorEntity):  # type: ignore
             self._attr_suggested_display_precision = 1
             self._attr_name = f"Power {self.scale_readable()}"
 
-    @cached_property
     def device_info(self) -> DeviceInfo:
         """Return the device info."""
         device_name = self._channel.name or self._device.device_name
@@ -114,14 +113,12 @@ class CurrentVuePowerSensor(CoordinatorEntity, SensorEntity):  # type: ignore
             manufacturer="Emporia",
         )
 
-    @cached_property
     def last_reset(self) -> datetime | None:
-        """The time when the daily/monthly sensor was reset. Midnight local time."""
+        """Reset time of the daily/monthly sensor. Midnight local time."""
         if self._id in self.coordinator.data:
             return self.coordinator.data[self._id]["reset"]
         return None
 
-    @cached_property
     def native_value(self) -> float | None:
         """Return the state of the sensor."""
         if self._id in self.coordinator.data:
@@ -129,9 +126,8 @@ class CurrentVuePowerSensor(CoordinatorEntity, SensorEntity):  # type: ignore
             return self.scale_usage(usage) if usage is not None else None
         return None
 
-    @cached_property
     def unique_id(self) -> str:
-        """Unique ID for the sensor."""
+        """Return the Unique ID for the sensor."""
         if self._scale == Scale.MINUTE.value:
             return (
                 "sensor.emporia_vue.instant."

--- a/custom_components/emporia_vue/strings.json
+++ b/custom_components/emporia_vue/strings.json
@@ -9,6 +9,15 @@
           "enable_1d": "Energy Today Sensor",
           "enable_1mon": "Energy This Month Sensor"
         }
+      },
+      "reconfigure": {
+        "enable_1m": "Power Minute Average Sensor",
+        "enable_1d": "Energy Today Sensor",
+        "enable_1mon": "Energy This Month Sensor"
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "The Emporia Vue integration needs to re-authenticate your account"
       }
     },
     "error": {
@@ -17,20 +26,9 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
-    }
-  },
-  "options": {
-    "step": {
-      "init": {
-        "data": {
-          "email": "[%key:common::config_flow::data::email%]",
-          "password": "[%key:common::config_flow::data::password%]",
-          "enable_1m": "Power Minute Average Sensor",
-          "enable_1d": "Energy Today Sensor",
-          "enable_1mon": "Energy This Month Sensor"
-        }
-      }
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   }
 }

--- a/custom_components/emporia_vue/strings.json
+++ b/custom_components/emporia_vue/strings.json
@@ -11,13 +11,19 @@
         }
       },
       "reconfigure": {
-        "enable_1m": "Power Minute Average Sensor",
-        "enable_1d": "Energy Today Sensor",
-        "enable_1mon": "Energy This Month Sensor"
+        "data": {
+          "enable_1m": "[%key:component::emporia_vue::config::step::user::data::enable_1m%]",
+          "enable_1d": "[%key:component::emporia_vue::config::step::user::data::enable_1d%]",
+          "enable_1mon": "[%key:component::emporia_vue::config::step::user::data::enable_1mon%]"
+        }
       },
       "reauth_confirm": {
         "title": "[%key:common::config_flow::title::reauth%]",
-        "description": "The Emporia Vue integration needs to re-authenticate your account"
+        "description": "The Emporia Vue integration needs to re-authenticate your account",
+        "data": {
+          "email": "[%key:common::config_flow::data::email%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
       }
     },
     "error": {

--- a/custom_components/emporia_vue/strings.json
+++ b/custom_components/emporia_vue/strings.json
@@ -8,7 +8,7 @@
           "enable_1m": "Power Minute Average Sensor",
           "enable_1d": "Energy Today Sensor",
           "enable_1mon": "Energy This Month Sensor",
-          "merged_behavior": "Merged Circuit Operation"
+          "solar_invert": "Invert Values for Solar Circuits"
         }
       },
       "reconfigure": {
@@ -16,7 +16,7 @@
           "enable_1m": "[%key:component::emporia_vue::config::step::user::data::enable_1m%]",
           "enable_1d": "[%key:component::emporia_vue::config::step::user::data::enable_1d%]",
           "enable_1mon": "[%key:component::emporia_vue::config::step::user::data::enable_1mon%]",
-          "merged_behavior": "[%key:component::emporia_vue::config::step::user::data::merged_behavior%]"
+          "solar_invert": "[%key:component::emporia_vue::config::step::user::data::solar_invert%]"
         }
       },
       "reauth_confirm": {

--- a/custom_components/emporia_vue/strings.json
+++ b/custom_components/emporia_vue/strings.json
@@ -7,14 +7,16 @@
           "password": "[%key:common::config_flow::data::password%]",
           "enable_1m": "Power Minute Average Sensor",
           "enable_1d": "Energy Today Sensor",
-          "enable_1mon": "Energy This Month Sensor"
+          "enable_1mon": "Energy This Month Sensor",
+          "merged_behavior": "Merged Circuit Operation"
         }
       },
       "reconfigure": {
         "data": {
           "enable_1m": "[%key:component::emporia_vue::config::step::user::data::enable_1m%]",
           "enable_1d": "[%key:component::emporia_vue::config::step::user::data::enable_1d%]",
-          "enable_1mon": "[%key:component::emporia_vue::config::step::user::data::enable_1mon%]"
+          "enable_1mon": "[%key:component::emporia_vue::config::step::user::data::enable_1mon%]",
+          "merged_behavior": "[%key:component::emporia_vue::config::step::user::data::merged_behavior%]"
         }
       },
       "reauth_confirm": {

--- a/custom_components/emporia_vue/translations/en.json
+++ b/custom_components/emporia_vue/translations/en.json
@@ -1,34 +1,40 @@
 {
-  "config": {
-    "step": {
-      "user": {
-        "data": {
-          "email": "Email",
-          "password": "Password",
-          "enable_1m": "Power Minute Average Sensor",
-          "enable_1d": "Energy Today Sensor",
-          "enable_1mon": "Energy This Month Sensor"
-        }
-      },
-      "reconfigure": {
-        "enable_1m": "Power Minute Average Sensor",
-        "enable_1d": "Energy Today Sensor",
-        "enable_1mon": "Energy This Month Sensor"
-      },
-      "reauth_confirm": {
-        "title": "[%key:common::config_flow::title::reauth%]",
-        "description": "The Emporia Vue integration needs to re-authenticate your account"
-      }
-    },
-    "error": {
-      "cannot_connect": "Failed to connect",
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured",
+            "reauth_successful": "Re-authentication was successful",
+            "reconfigure_successful": "Re-configuration was successful"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",
             "unknown": "Unexpected error"
-    },
-    "abort": {
-      "already_configured": "Device is already configured",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+        },
+        "step": {
+            "reauth_confirm": {
+                "description": "The Emporia Vue integration needs to re-authenticate your account",
+                "title": "Authentication expired for {name}",
+                "data":{
+                    "email": "Email",
+                    "password": "Password"
+                }
+            },
+            "reconfigure": {
+                "data": {
+                    "enable_1d": "Energy Today Sensor",
+                    "enable_1m": "Power Minute Average Sensor",
+                    "enable_1mon": "Energy This Month Sensor"
+                }
+            },
+            "user": {
+                "data": {
+                    "email": "Email",
+                    "enable_1d": "Energy Today Sensor",
+                    "enable_1m": "Power Minute Average Sensor",
+                    "enable_1mon": "Energy This Month Sensor",
+                    "password": "Password"
+                }
+            }
+        }
     }
-  }
 }

--- a/custom_components/emporia_vue/translations/en.json
+++ b/custom_components/emporia_vue/translations/en.json
@@ -1,36 +1,34 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Device is already configured"
-        },
-        "error": {
-            "cannot_connect": "Failed to connect",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "email": "Email",
+          "password": "Password",
+          "enable_1m": "Power Minute Average Sensor",
+          "enable_1d": "Energy Today Sensor",
+          "enable_1mon": "Energy This Month Sensor"
+        }
+      },
+      "reconfigure": {
+        "enable_1m": "Power Minute Average Sensor",
+        "enable_1d": "Energy Today Sensor",
+        "enable_1mon": "Energy This Month Sensor"
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "The Emporia Vue integration needs to re-authenticate your account"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",
             "unknown": "Unexpected error"
-        },
-        "step": {
-            "user": {
-                "data": {
-                    "email": "Email",
-                    "enable_1d": "Energy Today Sensor",
-                    "enable_1m": "Power Minute Average Sensor",
-                    "enable_1mon": "Energy This Month Sensor",
-                    "password": "Password"
-                }
-            }
-        }
     },
-    "options": {
-        "step": {
-            "init": {
-                "data": {
-                    "email": "Email",
-                    "enable_1d": "Energy Today Sensor",
-                    "enable_1m": "Power Minute Average Sensor",
-                    "enable_1mon": "Energy This Month Sensor",
-                    "password": "Password"
-                }
-            }
-        }
+    "abort": {
+      "already_configured": "Device is already configured",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
+  }
 }

--- a/custom_components/emporia_vue/translations/en.json
+++ b/custom_components/emporia_vue/translations/en.json
@@ -12,18 +12,19 @@
         },
         "step": {
             "reauth_confirm": {
-                "description": "The Emporia Vue integration needs to re-authenticate your account",
-                "title": "Authentication expired for {name}",
-                "data":{
+                "data": {
                     "email": "Email",
                     "password": "Password"
-                }
+                },
+                "description": "The Emporia Vue integration needs to re-authenticate your account",
+                "title": "Authentication expired for {name}"
             },
             "reconfigure": {
                 "data": {
                     "enable_1d": "Energy Today Sensor",
                     "enable_1m": "Power Minute Average Sensor",
-                    "enable_1mon": "Energy This Month Sensor"
+                    "enable_1mon": "Energy This Month Sensor",
+                    "merged_behavior": "Merged Circuit Operation"
                 }
             },
             "user": {
@@ -32,6 +33,7 @@
                     "enable_1d": "Energy Today Sensor",
                     "enable_1m": "Power Minute Average Sensor",
                     "enable_1mon": "Energy This Month Sensor",
+                    "merged_behavior": "Merged Circuit Operation",
                     "password": "Password"
                 }
             }

--- a/custom_components/emporia_vue/translations/en.json
+++ b/custom_components/emporia_vue/translations/en.json
@@ -24,7 +24,7 @@
                     "enable_1d": "Energy Today Sensor",
                     "enable_1m": "Power Minute Average Sensor",
                     "enable_1mon": "Energy This Month Sensor",
-                    "merged_behavior": "Merged Circuit Operation"
+                    "solar_invert": "Invert Values for Solar Circuits"
                 }
             },
             "user": {
@@ -33,8 +33,8 @@
                     "enable_1d": "Energy Today Sensor",
                     "enable_1m": "Power Minute Average Sensor",
                     "enable_1mon": "Energy This Month Sensor",
-                    "merged_behavior": "Merged Circuit Operation",
-                    "password": "Password"
+                    "password": "Password",
+                    "solar_invert": "Invert Values for Solar Circuits"
                 }
             }
         }


### PR DESCRIPTION
- Updates to config flows to support re-auth when password changes and reconfiguration to change the configuration normally set during initialization.
- Add config option to invert solar data, defaults to true. This should allow the user to choose if they want it inverted, since the energy dashboard requires positive data but emporia usually provides negative for generation.
- A bunch of typing and similar style updates
- Update some translation strings
- Add support for using the API simulator without dev code