### PR TITLE
Read the invert solar setting in the correct part of the flow

### DIFF
--- a/custom_components/emporia_vue/__init__.py
+++ b/custom_components/emporia_vue/__init__.py
@@ -69,10 +69,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     if not conf:
         return True
 
-    global INVERT_SOLAR
-    if SOLAR_INVERT in conf:
-        INVERT_SOLAR = conf[SOLAR_INVERT]
-
     hass.async_create_task(
         hass.config_entries.flow.async_init(
             DOMAIN,
@@ -96,6 +92,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Emporia Vue from a config entry."""
     global DEVICE_GIDS
     global DEVICE_INFORMATION
+    global INVERT_SOLAR
     DEVICE_GIDS = []
     DEVICE_INFORMATION = {}
 
@@ -103,6 +100,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.debug("Setting up Emporia Vue with entry data: %s", entry_data)
     email: str = entry_data[CONF_EMAIL]
     password: str = entry_data[CONF_PASSWORD]
+    if SOLAR_INVERT in entry_data:
+        INVERT_SOLAR = entry_data[SOLAR_INVERT]
     vue = PyEmVue()
     loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
     try:

--- a/custom_components/emporia_vue/manifest.json
+++ b/custom_components/emporia_vue/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/magico13/ha-emporia-vue/issues",
   "requirements": ["pyemvue==0.18.9"],
   "single_config_entry": true,
-  "version": "0.11.0"
+  "version": "0.11.1"
 }


### PR DESCRIPTION
This pull request introduces a minor refactor to the `async_setup` and `async_setup_entry` functions in the `custom_components/emporia_vue` integration and updates the version in the `manifest.json` file. The most important changes are detailed below:

### Refactor to configuration handling:

* Removed the setting of the `INVERT_SOLAR` global variable from the `async_setup` function. It is now initialized in the `async_setup_entry` function, where it is conditionally assigned based on `entry.data`. [[1]](diffhunk://#diff-b9cd036c286ca37bb13a1f16e8f20f8f567fad585a9d060b850c8fe4aadd8630L72-L75) [[2]](diffhunk://#diff-b9cd036c286ca37bb13a1f16e8f20f8f567fad585a9d060b850c8fe4aadd8630R95-R104)

### Version update:

* Updated the version in `manifest.json` from `0.11.0` to `0.11.1` to reflect the changes in the integration.