### PR TITLE
Fix for #381 - Extra keys not allowed in services.yaml

### DIFF
--- a/custom_components/emporia_vue/manifest.json
+++ b/custom_components/emporia_vue/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/magico13/ha-emporia-vue/issues",
   "requirements": ["pyemvue==0.18.9"],
   "single_config_entry": true,
-  "version": "0.11.1"
+  "version": "0.11.2"
 }

--- a/custom_components/emporia_vue/services.yaml
+++ b/custom_components/emporia_vue/services.yaml
@@ -10,10 +10,6 @@ set_charger_current:
       device_class: outlet
     device:
       manufacturer: Emporia
-      model: VVDN01
-      entity:
-        integration: emporia_vue
-        device_class: outlet
   # Different fields that your service accepts
   fields:
     # Key of the field


### PR DESCRIPTION
Fix for #381 - Extra keys not allowed in services.yaml. Not sure why this was allowed for so long and is now breaking, but I removed the nested entity key and loosened the model restriction since there are now multiple models for EVSEs.

Will no longer filter to just EVSEs unfortunately, instead filters to all "outlets" until EVSEs get their own device class. Calling it on an outlet will give a fairly clear error.