### PR TITLE
Fix for outlets and EVSEs no longer working

### DIFF
--- a/custom_components/emporia_vue/icons.json
+++ b/custom_components/emporia_vue/icons.json
@@ -1,0 +1,7 @@
+{
+  "services": {
+    "set_charger_current": {
+      "service": "mdi:ev-station"
+    }
+  }
+}

--- a/custom_components/emporia_vue/manifest.json
+++ b/custom_components/emporia_vue/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/magico13/ha-emporia-vue/issues",
   "requirements": ["pyemvue==0.18.9"],
   "single_config_entry": true,
-  "version": "0.11.2"
+  "version": "0.11.3"
 }

--- a/custom_components/emporia_vue/services.yaml
+++ b/custom_components/emporia_vue/services.yaml
@@ -1,27 +1,15 @@
 set_charger_current:
-  # Service name as shown in UI
-  name: Set Charger Current
-  # Description of the service
-  description: Sets the charging current for an EVSE/Charger.
-  # If the service accepts entity IDs, target allows the user to specify entities by entity, device, or area. If `target` is specified, `entity_id` should not be defined in the `fields` map. By default it shows only targets matching entities from the same domain as the service, but if further customization is required, target supports the entity, device, and area selectors (https://www.home-assistant.io/docs/blueprint/selectors/). Entity selector parameters will automatically be applied to device and area, and device selector parameters will automatically be applied to area.
+  # If the service accepts entity IDs, target allows the user to specify entities by entity, device, or area.
   target:
     entity:
       integration: emporia_vue
       device_class: outlet
-    device:
-      manufacturer: Emporia
   # Different fields that your service accepts
   fields:
     # Key of the field
     current:
-      # Field name as shown in UI
-      name: Charging Current
-      # Description of the field
-      description: The desired charging current in Amps.
       # Whether or not field is required (default = false)
       required: true
-      # Advanced fields are only shown when the advanced mode is enabled for the user (default = false)
-      advanced: false
       # Example value that can be passed for this field
       example: 6
       # The default field value

--- a/custom_components/emporia_vue/strings.json
+++ b/custom_components/emporia_vue/strings.json
@@ -38,5 +38,17 @@
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
+  },
+  "services": {
+    "set_charger_current": {
+      "name": "Set charger current",
+      "description": "Sets the charging current for an EVSE/charger",
+      "fields": {
+        "current": {
+          "name": "Charging current",
+          "description": "The desired charging current in amps"
+        }
+      }
+    }
   }
 }

--- a/custom_components/emporia_vue/switch.py
+++ b/custom_components/emporia_vue/switch.py
@@ -37,7 +37,7 @@ async def __async_update_data(vue: PyEmVue):
     try:
         # Note: asyncio.TimeoutError and aiohttp.ClientError are already
         # handled by the data update coordinator.
-        data : dict[str, Any] = {}
+        data: dict[str, Any] = {}
         loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
         outlets: list[OutletDevice]
         chargers: list[ChargerDevice]
@@ -65,7 +65,6 @@ async def async_setup_entry(
     devices: list[VueDevice] = await loop.run_in_executor(None, vue.get_devices)
     for device in devices:
         if device.outlet or device.ev_charger:
-            await loop.run_in_executor(None, vue.populate_device_properties, device)
             device_information[str(device.device_gid)] = device
 
     async def async_update_data():
@@ -108,7 +107,9 @@ async def async_setup_entry(
 class EmporiaOutletSwitch(CoordinatorEntity, SwitchEntity):  # type: ignore
     """Representation of an Emporia Smart Outlet state."""
 
-    def __init__(self, coordinator: DataUpdateCoordinator[dict[str, Any]], vue: PyEmVue, gid: str) -> None:
+    def __init__(
+        self, coordinator: DataUpdateCoordinator[dict[str, Any]], vue: PyEmVue, gid: str
+    ) -> None:
         """Pass coordinator to CoordinatorEntity."""
         super().__init__(coordinator)
         self._vue = vue

--- a/custom_components/emporia_vue/translations/en.json
+++ b/custom_components/emporia_vue/translations/en.json
@@ -38,5 +38,17 @@
                 }
             }
         }
+    },
+    "services": {
+        "set_charger_current": {
+            "description": "Sets the charging current for an EVSE/charger",
+            "fields": {
+                "current": {
+                    "description": "The desired charging current in amps",
+                    "name": "Charging current"
+                }
+            },
+            "name": "Set charger current"
+        }
     }
 }


### PR DESCRIPTION
Removed the failing call to get location properties, the API started returning that natively a while back so the call wasn't necessary anymore anyway.

Additionally tweaks the service description for setting the EVSE current. Still might need to tweak that further to match the latest expectations but this should be an improvement toward that. Longer term I want to get back to it only showing EVSEs in the list instead of all outlets but it's better than nothing!

