### PR TITLE
fix: preserve sign for bidirectional merged channels

### DIFF
--- a/custom_components/emporia_vue/__init__.py
+++ b/custom_components/emporia_vue/__init__.py
@@ -51,6 +51,7 @@ from .const import (
     SOLAR_INVERT,
     VUE_DATA,
 )
+from .helpers import merged_channel_is_bidirectional
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -643,6 +644,10 @@ async def parse_flattened_usage_data(
                 )
 
             bidirectional = "bidirectional" in info_channel.type.lower()
+            if not bidirectional:
+                bidirectional = merged_channel_is_bidirectional(
+                    info_channel, info.channels
+                )
             is_solar = info_channel.channel_type_gid == 13
             fixed_usage = fix_usage_sign(
                 channel_num, fixed_usage, bidirectional, is_solar, INVERT_SOLAR

--- a/custom_components/emporia_vue/helpers.py
+++ b/custom_components/emporia_vue/helpers.py
@@ -1,0 +1,29 @@
+"""Helpers for interpreting Emporia channel metadata."""
+
+from collections.abc import Iterable
+from typing import Protocol
+
+
+class ChannelMetadata(Protocol):
+    """The channel fields used to classify merged Emporia circuits."""
+
+    channel_num: str
+    parent_channel_num: str | None
+    type: str
+
+
+def merged_channel_is_bidirectional(
+    channel: ChannelMetadata, channels: Iterable[ChannelMetadata]
+) -> bool:
+    """Return whether a merged channel has one or more all-bidirectional children."""
+    if channel.type.lower() != "merged":
+        return False
+
+    children = [
+        candidate
+        for candidate in channels
+        if candidate.parent_channel_num == channel.channel_num
+    ]
+    return bool(children) and all(
+        "bidirectional" in child.type.lower() for child in children
+    )

--- a/tests/test_merged_channels.py
+++ b/tests/test_merged_channels.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+HELPERS_PATH = (
+    Path(__file__).parents[1] / "custom_components" / "emporia_vue" / "helpers.py"
+)
+spec = importlib.util.spec_from_file_location("emporia_vue_helpers", HELPERS_PATH)
+assert spec is not None and spec.loader is not None
+helpers = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(helpers)
+merged_channel_is_bidirectional = helpers.merged_channel_is_bidirectional
+
+
+@dataclass
+class Channel:
+    channel_num: str
+    type: str
+    parent_channel_num: str | None = None
+
+
+class MergedChannelBidirectionalityTest(unittest.TestCase):
+    def test_merged_channel_is_bidirectional_when_all_direct_children_are_bidirectional(self):
+        merged = Channel(channel_num="97", type="Merged")
+        children = [
+            Channel(channel_num="12", type="FiftyAmpBidirectional", parent_channel_num="97"),
+            Channel(channel_num="13", type="FiftyAmpBidirectional", parent_channel_num="97"),
+        ]
+
+        self.assertTrue(merged_channel_is_bidirectional(merged, [merged, *children]))
+
+    def test_merged_channel_is_not_bidirectional_when_any_direct_child_is_not_bidirectional(self):
+        merged = Channel(channel_num="97", type="Merged")
+        children = [
+            Channel(channel_num="12", type="FiftyAmpBidirectional", parent_channel_num="97"),
+            Channel(channel_num="13", type="FiftyAmp", parent_channel_num="97"),
+        ]
+
+        self.assertFalse(merged_channel_is_bidirectional(merged, [merged, *children]))
+
+    def test_merged_channel_is_not_bidirectional_when_it_has_no_direct_children(self):
+        merged = Channel(channel_num="97", type="Merged")
+
+        self.assertFalse(merged_channel_is_bidirectional(merged, [merged]))
+
+    def test_non_merged_channel_is_not_classified_by_child_metadata(self):
+        branch = Channel(channel_num="12", type="FiftyAmp")
+        child = Channel(channel_num="13", type="FiftyAmpBidirectional", parent_channel_num="12")
+
+        self.assertFalse(merged_channel_is_bidirectional(branch, [branch, child]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Treat a `Merged` Emporia channel as bidirectional only when it has one or more direct children and every direct child type contains `Bidirectional`.
- Keep existing behavior for non-merged channels, merged channels with no children, and merged channels with any non-bidirectional child.
- Add regression coverage for all-bidirectional, mixed-child, childless, and non-merged cases.

## Provenance
This is a clean cherry-pick of ianespana/ha-emporia-vue#3 onto current upstream `master` (`11db03e`). It intentionally excludes unrelated fork changes, including the separate timing work.

## Evidence
Live Emporia metadata reported a `Merged` parent with direct children that were all `FiftyAmpBidirectional`; the previous parent type-only classification invoked `abs()` and discarded signed usage.

Image shows the power for my merged circuit being reported as positive before the fix, even though this is generated power, not consumed power. After the fix we have the correct sign (negative for production)
<img width="1186" height="531" alt="image" src="https://github.com/user-attachments/assets/0efaa2a5-d5ec-421b-bdcc-4459ede61824" />

## Tests
- `python3 -m unittest discover -s tests -v`
- `python3 -m py_compile custom_components/emporia_vue/helpers.py custom_components/emporia_vue/__init__.py`
- `git diff upstream/master...HEAD --check`