### PR TITLE
Tolerate API timeouts and expose telemetry diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ Configuration is done directly in the Home Assistant UI, no manual config file e
 5. In the UI that opens, enter the email and password used for the Emporia App. If your account uses Google/Apple, see the [Google/Apple Accounts](#googleapple-accounts) section below.
 6. Done! You should now have a sensor for each "channel".
 
+### API Diagnostics
+
+The integration creates two diagnostic sensors for monitoring Emporia cloud
+reliability:
+
+- **Emporia API Retries** counts recoverable update failures since the
+  integration was loaded. Its attributes break out total and consecutive
+  retries for minute, daily, and monthly telemetry.
+- **Emporia API Latency** records the latest minute telemetry update duration
+  in milliseconds. This is the end-to-end API update time because PyEmVue does
+  not expose the underlying HTTP response's connection-only timing.
+
+Brief outages retain the last successful telemetry for two failed polls. A
+third consecutive failure marks the affected telemetry unavailable until the
+API recovers.
+
 ### Google/Apple Accounts
 
 If your Emporia account was created via Sign in with Google or Apple, the easiest solution is to **set an Emporia password** using the create account flow on the Emporia website or app using the same email address as you'd use with Google/Apple. Once set, you can log in using the standard email and password method above.

--- a/custom_components/emporia_vue/__init__.py
+++ b/custom_components/emporia_vue/__init__.py
@@ -51,6 +51,7 @@ from .const import (
     SOLAR_INVERT,
     VUE_DATA,
 )
+from .resilience import TolerantUpdateMethod, is_newer_sample
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -73,9 +74,13 @@ DEVICES_ONLINE: list[str] = []
 LAST_MINUTE_DATA: dict[str, Any] = {}
 LAST_DAY_DATA: dict[str, Any] = {}
 LAST_DAY_UPDATE: datetime | None = None
+LAST_DAY_INTEGRATED_MINUTE: dict[str, datetime] = {}
 LAST_MONTH_DATA: dict[str, Any] = {}
 LAST_MONTH_UPDATE: datetime | None = None
+LAST_MONTH_INTEGRATED_MINUTE: dict[str, datetime] = {}
 INVERT_SOLAR: bool = True
+
+TOLERATED_UPDATE_FAILURES = 2
 
 
 def redact_config_data(data: Mapping[str, Any]) -> dict[str, Any]:
@@ -147,6 +152,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     global INVERT_SOLAR
     DEVICE_GIDS = []
     DEVICE_INFORMATION = {}
+    LAST_DAY_INTEGRATED_MINUTE.clear()
+    LAST_MONTH_INTEGRATED_MINUTE.clear()
 
     entry_data = entry.data
     _LOGGER.debug(
@@ -257,11 +264,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         ):
                             # if we just passed midnight, then reset back to zero
                             timestamp: datetime = data["timestamp"]
+                            if not is_newer_sample(
+                                LAST_DAY_INTEGRATED_MINUTE, day_id, timestamp
+                            ):
+                                continue
                             await check_for_midnight(timestamp, int(device_gid), day_id)
 
                             LAST_DAY_DATA[day_id]["usage"] += data[
                                 "usage"
                             ]  # already in kwh
+                            LAST_DAY_INTEGRATED_MINUTE[day_id] = timestamp
             return LAST_DAY_DATA
 
         async def async_update_month_sensors() -> dict:
@@ -295,21 +307,35 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         ):
                             # if we just passed the billing cycle start, reset back to zero
                             timestamp: datetime = data["timestamp"]
+                            if not is_newer_sample(
+                                LAST_MONTH_INTEGRATED_MINUTE, month_id, timestamp
+                            ):
+                                continue
                             await check_for_new_month(timestamp, int(device_gid), month_id)
 
                             LAST_MONTH_DATA[month_id]["usage"] += data[
                                 "usage"
                             ]  # already in kwh
+                            LAST_MONTH_INTEGRATED_MINUTE[month_id] = timestamp
             return LAST_MONTH_DATA
 
         coordinator_1min = None
+        retry_update_methods: dict[str, TolerantUpdateMethod] = {}
         if ENABLE_1M not in entry_data or entry_data[ENABLE_1M]:
+            minute_update_method = TolerantUpdateMethod(
+                async_update_data_1min,
+                name="Minute telemetry",
+                logger=_LOGGER,
+                recoverable_exceptions=(UpdateFailed,),
+                tolerated_failures=TOLERATED_UPDATE_FAILURES,
+            )
+            retry_update_methods["minute"] = minute_update_method
             coordinator_1min = DataUpdateCoordinator(
                 hass,
                 _LOGGER,
                 # Name of the data. For logging purposes.
-                name="sensor",
-                update_method=async_update_data_1min,
+                name="minute telemetry",
+                update_method=minute_update_method,
                 # Polling interval. Will only be polled if there are subscribers.
                 update_interval=timedelta(minutes=1),
             )
@@ -317,12 +343,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             _LOGGER.debug("1min Update data: %s", coordinator_1min.data)
         coordinator_1mon = None
         if ENABLE_1MON not in entry_data or entry_data[ENABLE_1MON]:
+            monthly_update_method = TolerantUpdateMethod(
+                async_update_month_sensors,
+                name="Monthly telemetry",
+                logger=_LOGGER,
+                recoverable_exceptions=(UpdateFailed,),
+                tolerated_failures=TOLERATED_UPDATE_FAILURES,
+            )
+            retry_update_methods["monthly"] = monthly_update_method
             coordinator_1mon = DataUpdateCoordinator(
                 hass,
                 _LOGGER,
                 # Name of the data. For logging purposes.
-                name="sensor",
-                update_method=async_update_month_sensors,
+                name="monthly telemetry",
+                update_method=monthly_update_method,
                 # Polling interval. Will only be polled if there are subscribers.
                 update_interval=timedelta(minutes=1),
             )
@@ -331,12 +365,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         coordinator_day_sensor = None
         if ENABLE_1D not in entry_data or entry_data[ENABLE_1D]:
+            daily_update_method = TolerantUpdateMethod(
+                async_update_day_sensors,
+                name="Daily telemetry",
+                logger=_LOGGER,
+                recoverable_exceptions=(UpdateFailed,),
+                tolerated_failures=TOLERATED_UPDATE_FAILURES,
+            )
+            retry_update_methods["daily"] = daily_update_method
             coordinator_day_sensor = DataUpdateCoordinator(
                 hass,
                 _LOGGER,
                 # Name of the data. For logging purposes.
-                name="sensor",
-                update_method=async_update_day_sensors,
+                name="daily telemetry",
+                update_method=daily_update_method,
                 # Polling interval. Will only be polled if there are subscribers.
                 update_interval=timedelta(minutes=1),
             )
@@ -497,6 +539,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "coordinator_day_sensor": coordinator_day_sensor,
         "coordinator_device_status": coordinator_device_status,
         "device_information": DEVICE_INFORMATION,
+        "retry_update_methods": retry_update_methods,
     }
 
     try:
@@ -557,7 +600,7 @@ async def update_sensors(vue: PyEmVue, scales: list[str]) -> dict:
 
         return data
     except Exception as err:
-        _LOGGER.error("Error communicating with Emporia API: %s", err)
+        _LOGGER.debug("Error communicating with Emporia API", exc_info=True)
         raise UpdateFailed(f"Error communicating with Emporia API: {err}") from err
 
 

--- a/custom_components/emporia_vue/resilience.py
+++ b/custom_components/emporia_vue/resilience.py
@@ -1,0 +1,133 @@
+"""Helpers for tolerating brief Emporia cloud interruptions."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+import logging
+from time import monotonic
+from typing import Generic, TypeVar, cast
+
+_DataT = TypeVar("_DataT")
+_MISSING = object()
+
+
+def is_newer_sample(
+    integrated_samples: dict[str, datetime],
+    identifier: str,
+    timestamp: datetime,
+) -> bool:
+    """Return whether a minute sample is newer than the last integrated one."""
+    previous_timestamp = integrated_samples.get(identifier)
+    return previous_timestamp is None or timestamp > previous_timestamp
+
+
+class TolerantUpdateMethod(Generic[_DataT]):
+    """Reuse the last successful result during a bounded run of failures."""
+
+    def __init__(
+        self,
+        update_method: Callable[[], Awaitable[_DataT]],
+        *,
+        name: str,
+        logger: logging.Logger,
+        recoverable_exceptions: tuple[type[BaseException], ...],
+        tolerated_failures: int,
+    ) -> None:
+        """Initialize a timeout-tolerant update method."""
+        if tolerated_failures < 0:
+            raise ValueError("tolerated_failures must not be negative")
+
+        self._update_method = update_method
+        self._name = name
+        self._logger = logger
+        self._recoverable_exceptions = recoverable_exceptions
+        self._tolerated_failures = tolerated_failures
+        self._consecutive_failures = 0
+        self._total_failures = 0
+        self._last_failure: datetime | None = None
+        self._last_attempt: datetime | None = None
+        self._last_duration_ms: float | None = None
+        self._last_data: _DataT | object = _MISSING
+        self._listeners: set[Callable[[], None]] = set()
+
+    @property
+    def consecutive_failures(self) -> int:
+        """Return the current number of consecutive recoverable failures."""
+        return self._consecutive_failures
+
+    @property
+    def total_failures(self) -> int:
+        """Return the total recoverable failures since initialization."""
+        return self._total_failures
+
+    @property
+    def last_failure(self) -> datetime | None:
+        """Return the timestamp of the most recent recoverable failure."""
+        return self._last_failure
+
+    @property
+    def last_attempt(self) -> datetime | None:
+        """Return the timestamp of the most recent update attempt."""
+        return self._last_attempt
+
+    @property
+    def last_duration_ms(self) -> float | None:
+        """Return the duration of the most recent update attempt."""
+        return self._last_duration_ms
+
+    def add_listener(self, listener: Callable[[], None]) -> Callable[[], None]:
+        """Register a listener for retry telemetry changes."""
+        self._listeners.add(listener)
+
+        def remove_listener() -> None:
+            self._listeners.discard(listener)
+
+        return remove_listener
+
+    def _notify_listeners(self) -> None:
+        """Notify retry telemetry listeners without disrupting updates."""
+        for listener in tuple(self._listeners):
+            try:
+                listener()
+            except Exception:  # pylint: disable=broad-exception-caught
+                self._logger.exception("Error notifying %s retry listener", self._name)
+
+    async def __call__(self) -> _DataT:
+        """Fetch fresh data or briefly retain the last successful result."""
+        started = monotonic()
+        try:
+            data = await self._update_method()
+        except self._recoverable_exceptions as err:
+            self._consecutive_failures += 1
+            self._total_failures += 1
+            self._last_failure = datetime.now(timezone.utc)
+            if (
+                self._last_data is _MISSING
+                or self._consecutive_failures > self._tolerated_failures
+            ):
+                raise
+
+            self._logger.warning(
+                "%s update failed (%d/%d tolerated); retaining the last "
+                "successful data: %s",
+                self._name,
+                self._consecutive_failures,
+                self._tolerated_failures,
+                err,
+            )
+            return cast(_DataT, self._last_data)
+        else:
+            if self._consecutive_failures:
+                self._logger.info(
+                    "%s update recovered after %d failed attempt(s)",
+                    self._name,
+                    self._consecutive_failures,
+                )
+            self._consecutive_failures = 0
+            self._last_data = data
+            return data
+        finally:
+            self._last_duration_ms = (monotonic() - started) * 1000
+            self._last_attempt = datetime.now(timezone.utc)
+            self._notify_listeners()

--- a/custom_components/emporia_vue/sensor.py
+++ b/custom_components/emporia_vue/sensor.py
@@ -12,13 +12,14 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfEnergy, UnitOfPower
-from homeassistant.core import HomeAssistant
+from homeassistant.const import UnitOfEnergy, UnitOfPower, UnitOfTime
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+from .resilience import TolerantUpdateMethod
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -55,6 +56,14 @@ async def async_setup_entry(
             CurrentVuePowerSensor(coordinator_day_sensor, identifier)
             for _, identifier in enumerate(coordinator_day_sensor.data)
         )
+
+    retry_update_methods: dict[str, TolerantUpdateMethod] = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]["retry_update_methods"]
+    if retry_update_methods:
+        async_add_entities([EmporiaApiRetrySensor(retry_update_methods)])
+        if "minute" in retry_update_methods:
+            async_add_entities([EmporiaApiLatencySensor(retry_update_methods)])
 
     # Add charger status sensors
     coordinator_device_status = hass.data[DOMAIN][config_entry.entry_id][
@@ -200,6 +209,115 @@ class CurrentVuePowerSensor(CoordinatorEntity, SensorEntity):  # type: ignore
         return self._scale
 
 
+class EmporiaUpdateTelemetrySensor(SensorEntity):
+    """Base entity for Emporia cloud update telemetry."""
+
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        update_methods: dict[str, TolerantUpdateMethod],
+        listener_names: set[str] | None = None,
+    ) -> None:
+        """Initialize an update telemetry sensor."""
+        self._update_methods = update_methods
+        self._listener_names = listener_names
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to update telemetry changes."""
+        await super().async_added_to_hass()
+        for name, update_method in self._update_methods.items():
+            if self._listener_names is not None and name not in self._listener_names:
+                continue
+            self.async_on_remove(update_method.add_listener(self._handle_update))
+
+    @callback
+    def _handle_update(self) -> None:
+        """Write update telemetry changes to Home Assistant."""
+        self.async_write_ha_state()
+
+
+class EmporiaApiRetrySensor(EmporiaUpdateTelemetrySensor):
+    """Expose cloud retry telemetry in Home Assistant."""
+
+    _attr_icon = "mdi:cloud-refresh"
+    _attr_name = "Emporia API Retries"
+    _attr_native_unit_of_measurement = "retries"
+    _attr_unique_id = "sensor.emporia_vue.api_retries"
+
+    @property
+    def native_value(self) -> int:
+        """Return total retries across enabled telemetry coordinators."""
+        return sum(
+            update_method.total_failures
+            for update_method in self._update_methods.values()
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Return per-coordinator retry details."""
+        last_failures = [
+            update_method.last_failure
+            for update_method in self._update_methods.values()
+            if update_method.last_failure is not None
+        ]
+        return {
+            "retry_totals": {
+                name: update_method.total_failures
+                for name, update_method in self._update_methods.items()
+            },
+            "consecutive_retries": {
+                name: update_method.consecutive_failures
+                for name, update_method in self._update_methods.items()
+            },
+            "last_retry": max(last_failures).isoformat() if last_failures else None,
+        }
+
+
+class EmporiaApiLatencySensor(EmporiaUpdateTelemetrySensor):
+    """Expose end-to-end Emporia API update latency."""
+
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_icon = "mdi:timer-outline"
+    _attr_name = "Emporia API Latency"
+    _attr_native_unit_of_measurement = UnitOfTime.MILLISECONDS
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_unique_id = "sensor.emporia_vue.api_latency"
+
+    def __init__(
+        self,
+        update_methods: dict[str, TolerantUpdateMethod],
+    ) -> None:
+        """Initialize the API latency sensor."""
+        super().__init__(update_methods, listener_names={"minute"})
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the latest minute telemetry update duration in milliseconds."""
+        minute_update = self._update_methods.get("minute")
+        if not minute_update or minute_update.last_duration_ms is None:
+            return None
+        return round(minute_update.last_duration_ms, 1)
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Return per-coordinator update durations."""
+        minute_update = self._update_methods["minute"]
+        return {
+            "update_latency_ms": {
+                name: round(update_method.last_duration_ms, 1)
+                for name, update_method in self._update_methods.items()
+                if update_method.last_duration_ms is not None
+            },
+            "last_update_attempt": (
+                minute_update.last_attempt.isoformat()
+                if minute_update.last_attempt
+                else None
+            ),
+            "measurement": "end_to_end_update_duration",
+        }
+
+
 # Known Emporia charger API responses (from historical data):
 #   Status: "Charging", "Standby", "DeviceNotConnected", ""
 #   Messages: "Charging", "Ready", "Off", "Self Test", "Offline",
@@ -288,4 +406,3 @@ class EmporiaChargerStatusSensor(CoordinatorEntity, SensorEntity):  # type: igno
             sw_version=self._device.firmware,
             manufacturer="Emporia",
         )
-

--- a/info.md
+++ b/info.md
@@ -1,6 +1,6 @@
 # Emporia Vue Integration
 
-Adds a new sensor showing power consumption for the last minute, day, and month, for each power channel. Also supports Emporia switches and EVSEs. Configured right inside Home Assistant, no manual config file editing required.
+Adds a new sensor showing power consumption for the last minute, day, and month, for each power channel. Also supports Emporia switches and EVSEs, plus retry-count and API-latency diagnostic sensors. Configured right inside Home Assistant, no manual config file editing required.
 
 After installation, enable the integration in the Home Assistant integration configuration page, then choose an authentication method. Use email/password for normal Emporia accounts, or token authentication for accounts created with Sign in with Google or another SSO provider.
 

--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -1,0 +1,199 @@
+"""Tests for cloud-interruption tolerance helpers."""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from importlib.util import module_from_spec, spec_from_file_location
+import logging
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).parents[1]
+    / "custom_components"
+    / "emporia_vue"
+    / "resilience.py"
+)
+SPEC = spec_from_file_location("emporia_vue_resilience", MODULE_PATH)
+assert SPEC and SPEC.loader
+RESILIENCE = module_from_spec(SPEC)
+SPEC.loader.exec_module(RESILIENCE)
+TolerantUpdateMethod = RESILIENCE.TolerantUpdateMethod
+is_newer_sample = RESILIENCE.is_newer_sample
+
+
+class RecoverableError(Exception):
+    """Test-only recoverable update failure."""
+
+
+def test_retains_last_data_for_bounded_failures() -> None:
+    """The last successful data remains visible during brief failures."""
+
+    async def run_test() -> None:
+        results: list[dict[str, float] | BaseException] = [
+            {"power": 120.0},
+            RecoverableError("timeout one"),
+            RecoverableError("timeout two"),
+            RecoverableError("timeout three"),
+            {"power": 125.0},
+            {"power": 125.0},
+        ]
+
+        async def update() -> dict[str, float]:
+            result = results.pop(0)
+            if isinstance(result, BaseException):
+                raise result
+            return result
+
+        tolerant_update = TolerantUpdateMethod(
+            update,
+            name="minute telemetry",
+            logger=logging.getLogger(__name__),
+            recoverable_exceptions=(RecoverableError,),
+            tolerated_failures=2,
+        )
+        listener_calls = 0
+
+        def listener() -> None:
+            nonlocal listener_calls
+            listener_calls += 1
+
+        remove_listener = tolerant_update.add_listener(listener)
+
+        assert await tolerant_update() == {"power": 120.0}
+        assert listener_calls == 1
+        assert tolerant_update.last_attempt is not None
+        assert tolerant_update.last_duration_ms is not None
+        assert tolerant_update.last_duration_ms >= 0
+        assert await tolerant_update() == {"power": 120.0}
+        assert tolerant_update.consecutive_failures == 1
+        assert tolerant_update.total_failures == 1
+        assert tolerant_update.last_failure is not None
+        assert await tolerant_update() == {"power": 120.0}
+        assert tolerant_update.consecutive_failures == 2
+        assert tolerant_update.total_failures == 2
+
+        with pytest.raises(RecoverableError, match="timeout three"):
+            await tolerant_update()
+
+        assert tolerant_update.consecutive_failures == 3
+        assert tolerant_update.total_failures == 3
+        assert await tolerant_update() == {"power": 125.0}
+        assert tolerant_update.consecutive_failures == 0
+        assert listener_calls == 5
+
+        remove_listener()
+        assert await tolerant_update() == {"power": 125.0}
+        assert listener_calls == 5
+
+    asyncio.run(run_test())
+
+
+def test_first_refresh_failure_is_not_hidden() -> None:
+    """Setup still fails when no successful result has ever been cached."""
+
+    async def run_test() -> None:
+        async def update() -> dict[str, float]:
+            raise RecoverableError("initial timeout")
+
+        tolerant_update = TolerantUpdateMethod(
+            update,
+            name="minute telemetry",
+            logger=logging.getLogger(__name__),
+            recoverable_exceptions=(RecoverableError,),
+            tolerated_failures=2,
+        )
+
+        with pytest.raises(RecoverableError, match="initial timeout"):
+            await tolerant_update()
+
+    asyncio.run(run_test())
+
+
+def test_unexpected_failure_is_never_hidden() -> None:
+    """Only explicitly recoverable failures reuse cached data."""
+
+    async def run_test() -> None:
+        results: list[dict[str, float] | BaseException] = [
+            {"power": 120.0},
+            RuntimeError("programming error"),
+        ]
+
+        async def update() -> dict[str, float]:
+            result = results.pop(0)
+            if isinstance(result, BaseException):
+                raise result
+            return result
+
+        tolerant_update = TolerantUpdateMethod(
+            update,
+            name="minute telemetry",
+            logger=logging.getLogger(__name__),
+            recoverable_exceptions=(RecoverableError,),
+            tolerated_failures=2,
+        )
+
+        assert await tolerant_update() == {"power": 120.0}
+        with pytest.raises(RuntimeError, match="programming error"):
+            await tolerant_update()
+
+    asyncio.run(run_test())
+
+
+def test_rejects_negative_tolerance() -> None:
+    """A negative failure tolerance is invalid."""
+
+    async def update() -> dict[str, float]:
+        return {"power": 120.0}
+
+    with pytest.raises(ValueError, match="must not be negative"):
+        TolerantUpdateMethod(
+            update,
+            name="minute telemetry",
+            logger=logging.getLogger(__name__),
+            recoverable_exceptions=(RecoverableError,),
+            tolerated_failures=-1,
+        )
+
+
+def test_only_integrates_newer_minute_samples() -> None:
+    """Cached or out-of-order minute samples must not be counted twice."""
+    timestamp = datetime(2026, 8, 4, 20, 0, tzinfo=timezone.utc)
+    integrated_samples = {"device-channel": timestamp}
+
+    assert not is_newer_sample(integrated_samples, "device-channel", timestamp)
+    assert not is_newer_sample(
+        integrated_samples,
+        "device-channel",
+        timestamp - timedelta(minutes=1),
+    )
+    assert is_newer_sample(
+        integrated_samples,
+        "device-channel",
+        timestamp + timedelta(minutes=1),
+    )
+    assert is_newer_sample(integrated_samples, "new-channel", timestamp)
+
+
+def test_records_end_to_end_update_duration(monkeypatch) -> None:
+    """Update duration is measured using a monotonic clock."""
+    ticks = iter([10.0, 10.123])
+    monkeypatch.setattr(RESILIENCE, "monotonic", lambda: next(ticks))
+
+    async def run_test() -> None:
+        async def update() -> dict[str, float]:
+            return {"power": 120.0}
+
+        tolerant_update = TolerantUpdateMethod(
+            update,
+            name="minute telemetry",
+            logger=logging.getLogger(__name__),
+            recoverable_exceptions=(RecoverableError,),
+            tolerated_failures=2,
+        )
+
+        assert await tolerant_update() == {"power": 120.0}
+        assert tolerant_update.last_duration_ms == pytest.approx(123.0)
+        assert tolerant_update.last_attempt is not None
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary

- tolerate two consecutive recoverable Emporia telemetry update failures by retaining the last successful values
- mark telemetry unavailable again on the third consecutive failure until the API recovers
- prevent retained or out-of-order minute samples from being integrated twice into daily and monthly totals
- expose API retry counts and end-to-end update latency as diagnostic sensors
- document the resilience behavior and diagnostics

## Why

Brief Emporia cloud timeouts currently propagate through Home Assistant's data coordinators immediately, making otherwise stable telemetry unavailable. Retaining the last successful result for a short, bounded outage smooths those interruptions without concealing prolonged failures.

Reusing cached minute data also requires deduplication so daily and monthly energy totals are not inflated while an outage is being tolerated.

## User impact

During a brief Emporia API interruption, existing telemetry remains available for up to two failed polls. A third consecutive failure restores the normal unavailable behavior. Diagnostic entities expose retry totals, consecutive retries, the most recent retry, and update latency to help identify cloud reliability problems.

## Validation

- rebased onto current `magico13/master` (`11db03e`)
- `pytest -q`: 6 passed
- Python byte-compilation completed successfully
- `git diff --check`: clean
- behavior has been running successfully in Home Assistant against real telemetry

## Compatibility

The rebase preserves the current upstream dependency constraint for Home Assistant 2026.8 and the upstream 0.12.3 version.