### PR TITLE
fix: SSO token auth fails with TypeError in JWT verification

### DIFF
--- a/custom_components/emporia_vue/__init__.py
+++ b/custom_components/emporia_vue/__init__.py
@@ -51,7 +51,10 @@ from .const import (
     SOLAR_INVERT,
     VUE_DATA,
 )
+from .pycognito_compat import apply_pycognito_at_hash_compat
 from .resilience import TolerantUpdateMethod, is_newer_sample
+
+apply_pycognito_at_hash_compat()
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 

--- a/custom_components/emporia_vue/config_flow.py
+++ b/custom_components/emporia_vue/config_flow.py
@@ -31,6 +31,9 @@ from .const import (
     SOLAR_INVERT,
     TOKEN_CONFIG_FLOW_SCHEMA,
 )
+from .pycognito_compat import apply_pycognito_at_hash_compat
+
+apply_pycognito_at_hash_compat()
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 SENSITIVE_CONFIG_KEYS = {

--- a/custom_components/emporia_vue/pycognito_compat.py
+++ b/custom_components/emporia_vue/pycognito_compat.py
@@ -1,0 +1,80 @@
+"""Compatibility shims for pycognito + PyJWT on Python 3.13+."""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+_PATCHED = False
+
+
+def encode_token_for_digest(access_token: str | bytes) -> bytes:
+    """Return the access token as UTF-8 bytes for OIDC at_hash hashing."""
+    if isinstance(access_token, str):
+        return access_token.encode("utf-8")
+    return access_token
+
+
+def at_hash_from_digest(digest: bytes) -> str:
+    """Encode the left half of a digest as an OIDC at_hash string."""
+    return (
+        base64.urlsafe_b64encode(digest[: (len(digest) // 2)])
+        .decode("ascii")
+        .rstrip("=")
+    )
+
+
+def compute_at_hash(access_token: str | bytes, algorithm: str = "RS256") -> str:
+    """Compute the OIDC at_hash claim for an access token."""
+    import jwt
+
+    alg_obj = jwt.get_algorithm_by_name(algorithm)
+    digest = alg_obj.compute_hash_digest(encode_token_for_digest(access_token))
+    return at_hash_from_digest(digest)
+
+
+def apply_pycognito_at_hash_compat() -> None:
+    """Patch pycognito so Hosted UI / SSO ID tokens verify on modern PyJWT.
+
+    pycognito still hashes ``access_token`` as a ``str`` and then either
+    strips padding from ``bytes`` with a ``str`` or compares ``bytes`` to the
+    ``at_hash`` claim (``str``). PyJWT + cryptography on Python 3.13+ require
+    bytes for ``compute_hash_digest``, which raises TypeError during Google/SSO
+    token login.
+    """
+    global _PATCHED
+    if _PATCHED:
+        return
+
+    from jwt.algorithms import Algorithm
+    from pycognito import Cognito
+
+    original_verify = Cognito.verify_token
+    original_digest = Algorithm.compute_hash_digest
+    original_b64encode = base64.urlsafe_b64encode
+
+    def _compute_hash_digest(self: Any, bytestr: bytes | str) -> bytes:
+        digest = original_digest(self, encode_token_for_digest(bytestr))
+        # compute_hash_digest is only used in pycognito's at_hash block, which
+        # runs after JWT decode. Switch b64encode to a str so .rstrip("=") and
+        # comparison against the claim both succeed.
+        base64.urlsafe_b64encode = _urlsafe_b64encode_as_str
+        return digest
+
+    def _urlsafe_b64encode_as_str(payload: bytes | str) -> str:
+        encoded = original_b64encode(payload)
+        if isinstance(encoded, bytes):
+            return encoded.decode("ascii")
+        return encoded
+
+    def verify_token(self: Any, token: str, id_name: str, token_use: str) -> Any:
+        Algorithm.compute_hash_digest = _compute_hash_digest
+        try:
+            return original_verify(self, token, id_name, token_use)
+        finally:
+            Algorithm.compute_hash_digest = original_digest
+            base64.urlsafe_b64encode = original_b64encode
+
+    verify_token._emporia_at_hash_patched = True  # type: ignore[attr-defined]
+    Cognito.verify_token = verify_token  # type: ignore[method-assign]
+    _PATCHED = True

--- a/tests/test_pycognito_compat.py
+++ b/tests/test_pycognito_compat.py
@@ -1,0 +1,90 @@
+"""Tests for the pycognito at_hash compatibility shim."""
+
+from __future__ import annotations
+
+import base64
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).parents[1]
+    / "custom_components"
+    / "emporia_vue"
+    / "pycognito_compat.py"
+)
+SPEC = spec_from_file_location("emporia_vue_pycognito_compat", MODULE_PATH)
+assert SPEC and SPEC.loader
+COMPAT = module_from_spec(SPEC)
+SPEC.loader.exec_module(COMPAT)
+
+jwt = pytest.importorskip("jwt")
+
+
+def test_str_and_bytes_access_tokens_produce_the_same_at_hash() -> None:
+    """OIDC hashes the ASCII octets of the access token, whether str or bytes."""
+    access_token = "example-access-token"
+    from_str = COMPAT.compute_at_hash(access_token)
+    from_bytes = COMPAT.compute_at_hash(access_token.encode("utf-8"))
+
+    assert from_str == from_bytes
+    assert isinstance(from_str, str)
+    assert "=" not in from_str
+
+
+def test_unpatched_pyjwt_rejects_string_access_tokens() -> None:
+    """Reproduce the pycognito TypeError on modern PyJWT/cryptography."""
+    alg_obj = jwt.get_algorithm_by_name("RS256")
+
+    with pytest.raises(TypeError, match="bytestring|buffer"):
+        alg_obj.compute_hash_digest("example-access-token")
+
+
+def test_unpatched_at_hash_rstrip_and_compare_are_type_mismatched() -> None:
+    """After hashing, pycognito rstrip("=") on bytes and compares bytes to str."""
+    digest = jwt.get_algorithm_by_name("RS256").compute_hash_digest(
+        b"example-access-token"
+    )
+    encoded = base64.urlsafe_b64encode(digest[: (len(digest) // 2)])
+    claim = COMPAT.at_hash_from_digest(digest)
+
+    assert isinstance(encoded, bytes)
+    with pytest.raises(TypeError, match="bytes-like"):
+        encoded.rstrip("=")
+    assert encoded.rstrip(b"=").decode("ascii") == claim
+    assert encoded.rstrip(b"=") != claim
+
+
+def test_shim_makes_pycognito_at_hash_path_accept_str_tokens() -> None:
+    """The wrap must encode the token and compare at_hash as a string."""
+    pycognito = pytest.importorskip("pycognito")
+
+    access_token = "example-access-token"
+    expected = COMPAT.compute_at_hash(access_token)
+    captured: dict[str, Any] = {}
+
+    def broken_verify_token(self: Any, token: str, id_name: str, token_use: str) -> str:
+        alg_obj = jwt.get_algorithm_by_name("RS256")
+        digest = alg_obj.compute_hash_digest(self.access_token)
+        at_hash = base64.urlsafe_b64encode(digest[: (len(digest) // 2)]).rstrip("=")
+        captured["at_hash"] = at_hash
+        if at_hash != expected:
+            raise AssertionError("at_hash claim does not match access_token.")
+        return token
+
+    original = pycognito.Cognito.verify_token
+    COMPAT._PATCHED = False
+    pycognito.Cognito.verify_token = broken_verify_token
+    try:
+        COMPAT.apply_pycognito_at_hash_compat()
+
+        fake = type("FakeCognito", (), {"access_token": access_token})()
+        assert pycognito.Cognito.verify_token(fake, "id", "id_token", "id") == "id"
+        assert captured["at_hash"] == expected
+        assert isinstance(captured["at_hash"], str)
+    finally:
+        pycognito.Cognito.verify_token = original
+        COMPAT._PATCHED = False
+        COMPAT.apply_pycognito_at_hash_compat()


### PR DESCRIPTION
Fix #454 

## Summary
- Google/Apple (Hosted UI) setup failed in `async_step_tokens` with `TypeError: argument 'data': Cannot convert "<class 'str'>" instance to a buffer` while `pyemvue` refreshed Cognito tokens.
- Hosted UI ID tokens include OIDC `at_hash`. `pycognito` still hashes `access_token` as a `str` and then compares `bytes` to the claim (`str`). PyJWT + cryptography on Python 3.14 require bytes, so token login crashed before auth could succeed.
- Add a runtime compatibility shim that wraps `Cognito.verify_token`: encode the access token as UTF-8 for hashing, compare `at_hash` as an ASCII string, and restore the originals afterward so the rest of Home Assistant is untouched.
